### PR TITLE
Keep frozen positional encodings out of AdamW decay

### DIFF
--- a/experiments/z1t_scaling.py
+++ b/experiments/z1t_scaling.py
@@ -29,7 +29,7 @@ import wandb
 from jax.sharding import NamedSharding, PartitionSpec
 from tqdm import tqdm
 
-from z1t.components import active_params
+from z1t.components import active_params, weight_decay_mask
 from z1t.model import create_model
 from z1t.train import config_path, load_config, make_data, model_config, run_name
 
@@ -178,6 +178,7 @@ optimizer = optax.chain(
         b1=opt_cfg.get("b1", 0.9),
         b2=opt_cfg.get("b2", 0.95),
         weight_decay=opt_cfg.get("weight_decay", 0.1),
+        mask=weight_decay_mask(model),
     ),
 )
 opt_state = optimizer.init(eqx.filter(model, eqx.is_inexact_array))

--- a/research/z1t/components.py
+++ b/research/z1t/components.py
@@ -453,14 +453,18 @@ class Z1T(eqx.Module):
 
 
 def active_params(model) -> int:
-    """Parameters that actually participate in the forward pass.
+    """Trainable parameters that actually participate in the forward pass.
 
-    Mirrors `st.active_params`, but for z1t it always equals the raw parameter
-    count: `SparseLinear` stores an `(out, k)` weight and gathers its inputs, so
-    every stored weight is live. (st's `SparseLinear` keeps a dense weight and
-    masks it, so there the two numbers differ.) Kept so run metadata carries the
-    same field in both trees.
+    `PE.pe` is a frozen buffer, not a parameter. Otherwise every stored z1t
+    weight is live: `SparseLinear` stores only its `(out, k)` active weights.
     """
-    return sum(
-        int(x.size) for x in jax.tree.leaves(eqx.filter(model, eqx.is_inexact_array))
-    )
+    params = eqx.filter(model, eqx.is_inexact_array)
+    params = eqx.tree_at(lambda m: m.pe.pe, params, None)
+    return sum(int(x.size) for x in jax.tree.leaves(params))
+
+
+def weight_decay_mask(model):
+    """Apply AdamW decay to trainable arrays, excluding the frozen PE table."""
+    params = eqx.filter(model, eqx.is_inexact_array)
+    mask = jax.tree.map(lambda _: True, params)
+    return eqx.tree_at(lambda m: m.pe.pe, mask, False)

--- a/research/z1t/train.py
+++ b/research/z1t/train.py
@@ -30,7 +30,7 @@ import yaml
 from jax.sharding import PartitionSpec as P
 from tqdm import tqdm
 
-from z1t.components import AFT_KINDS, Config, active_params
+from z1t.components import AFT_KINDS, Config, active_params, weight_decay_mask
 from z1t.dataset import (
     make_addition,
     make_openwebtext,
@@ -309,6 +309,7 @@ def main():
             b1=opt_cfg.get("b1", 0.9),
             b2=opt_cfg.get("b2", 0.95),
             weight_decay=opt_cfg.get("weight_decay", 0.1),
+            mask=weight_decay_mask(model),
         ),
     )
     opt_state = optim.init(eqx.filter(model, eqx.is_inexact_array))


### PR DESCRIPTION
# Keep frozen positional encodings out of AdamW decay

## Summary

- Exclude the fixed sinusoidal positional-encoding table from AdamW weight decay.
- Apply the same mask in both Z1T training entrypoints.
- Exclude the frozen table from the active-parameter count.

## Problem

`PE.pe` is documented as a frozen buffer and is wrapped in `stop_gradient`, but
it is still a floating-point leaf in the model tree. Passing the full filtered
model to AdamW therefore applies decoupled weight decay to the table even though
its gradient is zero. This silently shrinks the positional-encoding amplitude
during training.

The learned gated-convolutional-attention parameters, including `w_conv`, are
unaffected by this issue and remain trainable.

## Changes

- Add a shared `weight_decay_mask()` helper that enables decay for trainable
  arrays while disabling it for `PE.pe`.
- Pass the mask to AdamW in `z1t.train` and `experiments.z1t_scaling`.
- Update `active_params()` so the frozen table is not reported as an active
  parameter.

## Verification

- Confirmed with an optimizer-level check that, given zero gradients:
  - ordinary model weights still decay;
  - `PE.pe` remains bit-for-bit unchanged;
  - the active-parameter count excludes the positional table.
- Ran Python bytecode compilation for `research/` and `experiments/`.
- Ran `git diff --check` successfully.